### PR TITLE
Fix timer reset when stopping other timers

### DIFF
--- a/lib/components/timer_card.dart
+++ b/lib/components/timer_card.dart
@@ -35,7 +35,6 @@ class _TimerCardState extends State<TimerCard> {
   @override
   Widget build(BuildContext context) {
     return Card(
-      key: UniqueKey(),
       color: AppColors.timerCardColor,
       clipBehavior: Clip.antiAlias,
       shape: RoundedRectangleBorder(

--- a/lib/modules/dashboard/presentation/home.dart
+++ b/lib/modules/dashboard/presentation/home.dart
@@ -141,6 +141,8 @@ class _TimerHomeState extends State<TimerHome>{
                     return _timerListStore.timerList.length > 0
                         ? ListTile(
                             title: TimerCard(
+                              key: ValueKey(
+                                  _timerListStore.timerList[index].id),
                               timerModel: _timerListStore.timerList[index],
                               onStop: () => _timerListStore.removeTimer(
                                   _timerListStore.timerList[index]),


### PR DESCRIPTION
## Summary
- ensure timers keep their state when others are stopped by providing stable keys
- remove per-build UniqueKey from timer card

## Testing
- ⚠️ `flutter test` *(command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68b7d2e2c36c8328801fcea6861da9a3